### PR TITLE
Fix permissions (when file on host is created with strict permissions)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM github-pages-base:latest
 
 RUN mkdir /home/jekyll/dependency_prep
-COPY Gemfile /home/jekyll/dependency_prep
+
+COPY --chown=jekyll:jekyll Gemfile /home/jekyll/dependency_prep
+RUN chmod -R 765 /home/jekyll/dependency_prep
 
 RUN cd /home/jekyll/dependency_prep && bundle-2.7 update
 


### PR DESCRIPTION
Seems like without this change the build fails for me with errors like 

``` 
/usr/lib/ruby/2.7.0/bundler/shared_helpers.rb:105:in `rescue in filesystem_access': There was an error while trying to read from `/home/jekyll/dependency_prep/Gemfile`. It is likely that you need to grant read permissions for that path. (Bundler::PermissionError)
```
because of UMASK configuration on my system.

